### PR TITLE
Refactor mascot.js into functions

### DIFF
--- a/functions/mascot/mascot.js
+++ b/functions/mascot/mascot.js
@@ -1,6 +1,6 @@
 /**
  * Mascot Bot
- */
+*/
 
 const {globalInterval,
   dropboxRefresh,
@@ -10,7 +10,7 @@ const {globalInterval,
   dropboxFolder,
   danId} = require(`/etc/Projects/MegaBot/vars.json`);
 
-const {Dropbox} = require(`dropbox`); // eslint-disable-line no-unused-vars
+const Dropbox = require(`dropbox`); // eslint-disable-line no-unused-vars
 
 const dropboxConfig = {
   refreshToken: dropboxRefresh,
@@ -20,55 +20,86 @@ const dropboxConfig = {
 
 const dbx = new Dropbox(dropboxConfig);
 
+/**
+* Fetches neccesary Discord objects
+* @param {Object} client The Discord client object
+* @return {Object} Two Discord objects we want to use send messages.
+*/
+async function fetchDiscordObjects(client) {
+  const mascotChannel = await client.channels.fetch(mascotchannelId).catch();
+  const user = await client.users.fetch(danId).catch();
+  return {mascotChannel, user};
+}
+
+/**
+* Queries Dropbox API for currently available files
+* @param {Object} User A variable that holds the Discord object
+* @param {String} mascotChannel The channel to send the mascot to
+* @return {Object} fileName and filePath from first of available files.
+*/
+async function getFile(User, mascotChannel) {
+  dbx.filesListFolder({path: dropboxFolder}).then((fileList) => {
+    const fileName = fileList.result.entries[0].name;
+    const filePath = fileList.result.entries[0].path_lower;
+    return {fileName, filePath};
+  }).catch((err) => {
+    console.error(err);
+    // Just a bit of fun if Dropbox doesn't return anything.
+    mascotChannel.send({
+      content: `${User} Man what the fuck there are no images left.`,
+    });
+  });
+}
+
+/**
+* Queries Dropbox API for a download link based on filepath
+* @param {String} filePath The Dropbox filepath
+* @return {String} Returns a temporary link to download said file
+*/
+async function getFileLink(filePath) {
+  const fileObject = dbx.filesGetTemporaryLink({path: filePath});
+  const fileLink = fileObject.result.link;
+  return fileLink;
+}
+
+/**
+* Sends a Discord message to mascotChannel with an an attachment.
+* @param {String} fileLink The Dropbox filepath for the attachment
+* @param {String} fileName The Dropbox filename for the attachment
+* @param {String} mascotChannel The channel to send the mascot to
+*/
+async function sendMascot(fileLink, fileName, mascotChannel) {
+  mascotChannel.send({
+    files: [{
+      attachment: fileLink,
+      name: fileName,
+    }],
+  }).catch((err) => {
+    console.error(err);
+  });
+}
+
+/**
+* Queries the Dropbox API to delete the file we posted
+* @param {Object} filePath The Dropbox filepath
+*/
+async function deleteFile(filePath) {
+  dbx.filesDeleteV2({path: filePath}).then((response) => {
+    console.log('Succesfully deleted file: ' +
+    response.result.metadata.path_display);
+  }).catch((err) => {
+    console.error(err);
+  });
+}
+
 module.exports = {
   masBot: async function(client) {
     setInterval(async () => {
-      // Fetch channels and save them in a const
-      const Mascot = await client.channels.fetch(mascotchannelId).catch();
-      const Dan = await client.users.fetch(danId).catch();
-      // Make sure they were fetched properly and continue
-      if (Mascot) {
-        dbx.filesListFolder({path: dropboxFolder})
-            .then((fileList) => {
-              const fileName = fileList.result.entries[0].name;
-              const filePath = fileList.result.entries[0].path_lower;
-              if (fileName && filePath) {
-                dbx.filesGetTemporaryLink({path: filePath})
-                    .then((fileLink) => {
-                      const Link = fileLink.result.link;
-                      const mascotMessage = Mascot.send({
-                        files: [{
-                          attachment: Link,
-                          name: fileName,
-                        }],
-                      }).catch((err) => {
-                        console.error(err);
-                      });
-                      if (mascotMessage) {
-                        dbx.filesDeleteV2({path: filePath})
-                            .then((response) => {
-                              console.log('Succesfully deleted file: ' +
-                                response.result.metadata.path_display);
-                            })
-                            .catch((err) => {
-                              console.error(err);
-                            });
-                      }
-                    })
-                    .catch((err) => {
-                      console.error(err);
-                    });
-              }
-            })
-            .catch((err) => {
-              console.error(err);
-              Mascot.send({
-                content: `${Dan} Man what the fuck there are no images left.`,
-              });
-            });
-      } else {
-        console.log('Couldn\'t find that channel man, shit sucks big time.');
-      }
+      const {mascotChannel, user} = fetchDiscordObjects(client);
+      const {fileName, filePath} = getFile(user, mascotChannel);
+      const fileLink = getFileLink(filePath);
+      sendMascot(fileLink, fileName, mascotChannel);
+      deleteFile(filePath);
     }, globalInterval);
   },
 };

--- a/functions/mascot/mascot.js
+++ b/functions/mascot/mascot.js
@@ -33,11 +33,11 @@ async function fetchDiscordObjects(client) {
 
 /**
 * Queries Dropbox API for currently available files
-* @param {Object} User A variable that holds the Discord object
+* @param {Object} user A variable that holds the Discord object
 * @param {String} mascotChannel The channel to send the mascot to
 * @return {Object} fileName and filePath from first of available files.
 */
-async function getFile(User, mascotChannel) {
+async function getFile(user, mascotChannel) {
   dbx.filesListFolder({path: dropboxFolder}).then((fileList) => {
     const fileName = fileList.result.entries[0].name;
     const filePath = fileList.result.entries[0].path_lower;
@@ -46,7 +46,7 @@ async function getFile(User, mascotChannel) {
     console.error(err);
     // Just a bit of fun if Dropbox doesn't return anything.
     mascotChannel.send({
-      content: `${User} Man what the fuck there are no images left.`,
+      content: `${user} Man what the fuck there are no images left.`,
     });
   });
 }


### PR DESCRIPTION
This gets rid of the indentation by turning everything into functions and just calling those instead.